### PR TITLE
Enable slapd when starting it

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,6 +27,7 @@
   service:
     name: slapd
     state: started
+    enabled: yes
 
 - name: Copy LDIF files to server
   copy:


### PR DESCRIPTION
@lindareijnhoudt : not sure why, but it seems that this caused `slapd` to fail to start.